### PR TITLE
Boost

### DIFF
--- a/src/Avatar.elm
+++ b/src/Avatar.elm
@@ -13,6 +13,10 @@ defaultSpeed : Float
 defaultSpeed =
     6.0
 
+type alias Speed =
+  { multiplier : Float
+  , timeLimit : Int
+  }
 
 type alias Avatar =
     { x : Float
@@ -21,7 +25,7 @@ type alias Avatar =
     , vy : Float
     , dir : Direction
     , hp : Int
-    , speedMultiplier : Float
+    , speed : Speed
     , invincible : Bool
     }
 
@@ -39,10 +43,9 @@ initialAvatar =
     , vy = 0
     , dir = Right
     , hp = 100
-    , speedMultiplier = 1.0
+    , speed = { multiplier = 1.0 , timeLimit = 0 }
     , invincible = False
     }
-
 
 jump : Avatar -> List GamePlatform -> Avatar
 jump avatar platforms =
@@ -63,7 +66,7 @@ walk newVx avatar =
             else
                 avatar.dir
         , vx =
-            newVx * avatar.speedMultiplier
+            newVx * avatar.speed.multiplier
     }
 
 

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -135,6 +135,7 @@ status : Maybe GamePlatform -> Avatar -> Avatar
 status platform avatar =
     { avatar
         | hp = updateHp platform avatar
+        , speedMultiplier = updateSpeed platform avatar
     }
 
 
@@ -154,6 +155,21 @@ updateHp platform avatar =
         0
     else
         avatar.hp
+
+updateSpeed : Maybe GamePlatform -> Avatar -> Float
+updateSpeed platform avatar =
+    if isCollidingUnit avatar platform then
+        case platform of
+          Just platform ->
+            case platform.unit of
+              Boost -> min (avatar.speedMultiplier + 0.5) 2.0
+              _ -> avatar.speedMultiplier
+          Nothing ->
+            avatar.speedMultiplier
+    else if avatar.y < ViewUtil.pit then
+        0
+    else
+        avatar.speedMultiplier
 
 
 isCollidingUnit : Avatar -> Maybe GamePlatform -> Bool

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -135,7 +135,7 @@ status : Maybe GamePlatform -> Avatar -> Avatar
 status platform avatar =
     { avatar
         | hp = updateHp platform avatar
-        , speedMultiplier = updateSpeed platform avatar
+        , speed = updateSpeed platform avatar
     }
 
 
@@ -156,21 +156,34 @@ updateHp platform avatar =
     else
         avatar.hp
 
-updateSpeed : Maybe GamePlatform -> Avatar -> Float
+updateSpeed : Maybe GamePlatform -> Avatar -> Speed
 updateSpeed platform avatar =
     if isCollidingUnit avatar platform then
         case platform of
           Just platform ->
             case platform.unit of
-              Boost -> min (avatar.speedMultiplier + 0.5) 2.0
-              _ -> avatar.speedMultiplier
+              Boost -> {
+                            multiplier = min (avatar.speed.multiplier + 0.5) 2.0
+                          , timeLimit = 100
+                        }
+              _ -> avatar.speed
           Nothing ->
-            avatar.speedMultiplier
+            avatar.speed
     else if avatar.y < ViewUtil.pit then
-        0
+        avatar.speed
     else
-        avatar.speedMultiplier
+        checkTimeLimit avatar
 
+checkTimeLimit : Avatar -> Speed
+checkTimeLimit avatar =
+  if avatar.speed.timeLimit > 0 then
+    { multiplier = avatar.speed.multiplier
+    , timeLimit = max (avatar.speed.timeLimit - 1) 0
+    }
+  else
+    { multiplier = 1.0
+    , timeLimit = 0
+    }
 
 isCollidingUnit : Avatar -> Maybe GamePlatform -> Bool
 isCollidingUnit avatar platform =

--- a/src/GamePlatform.elm
+++ b/src/GamePlatform.elm
@@ -36,6 +36,7 @@ type Unit
     | Health
     | TwoBones
     | ThreeBones
+    | Boost
     | None
 
 
@@ -67,6 +68,8 @@ assignUnit generated =
       Waste
     else if generated < 11 then
       TwoBones
+    else if generated < 13 then
+      Boost
     else if generated < 14 then
       ThreeBones
     else if generated < 15 then
@@ -107,6 +110,7 @@ hasCollectible platform =
   case platform of
     Just platform ->
       case platform.unit of
+        Boost -> True
         Health -> True
         TwoBones -> True
         ThreeBones -> True

--- a/src/View.elm
+++ b/src/View.elm
@@ -110,6 +110,8 @@ platformUnitForm platform =
                 "collectible/health"
             else if platform.unit == TwoBones then
                 "collectible/bones_2"
+            else if platform.unit == Boost then
+                "collectible/boost"
             else
                 "collectible/bones_3"
 

--- a/src/View.elm
+++ b/src/View.elm
@@ -141,7 +141,7 @@ avatarElement game =
             else if onPlatform game.avatar game.platforms /= True then
                 "jump"
             else if game.avatar.vx /= 0 then
-                if game.avatar.speedMultiplier >= 1.5 then
+                if game.avatar.speed.multiplier >= 1.5 then
                     "run"
                 else
                     "walk"
@@ -177,7 +177,7 @@ uiContent game =
     "HP : "
         ++ toString game.avatar.hp
         ++ "\nSPEED X "
-        ++ toString game.avatar.speedMultiplier
+        ++ toString game.avatar.speed.multiplier
         ++ "\nSCORE : "
         ++ getScoreString game.score
 


### PR DESCRIPTION
One bug I noticed with this is if you continue to hold the key down while you hit the boost collectible, you won't increase your actual running speed until you release it and start again. 

This also applies to when the time limit runs out; you can keep your speed boost as long as you don't let go of the key. It's like the movie Speed!

Wasn't sure how to approach this bug for now, but the general functionality of boost works.